### PR TITLE
Use new `express-authentication-header` library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
 - '0.11'

--- a/lib/bearer.js
+++ b/lib/bearer.js
@@ -2,77 +2,15 @@
 'use strict';
 
 var _ = require('lodash'),
-	header = require('auth-header'),
-	async = require('express-async');
+	header = require('express-authentication-header');
 
-module.exports = function bearer(options) {
-
-	// Defaults
+module.exports = function create(options) {
 	if (_.isFunction(options)) {
-		options = { verify: options };
+		options = {
+			verify: options
+		};
 	}
-
-	options = _.defaults(options, {
-		from: [ 'header', 'body', 'query' ]
-	});
-
-	// Safety
-	if (!_.isObject(options)) {
-		throw new TypeError();
-	} else if (!_.isFunction(options.verify)) {
-		throw new TypeError();
-	}
-
-	function fromQueryString(req, res, next) {
-		if (req.query.access_token) {
-			req.challenge = {
-				token: req.query.access_token
-			};
-		}
-		next();
-	}
-
-	function fromHeader(req, res, next) {
-		if (req.get('Authorization')) {
-			req.challenge = header.parse(req.get('Authorization'));
-		}
-		next();
-	}
-
-	function fromBody(req, res, next) {
-		if (req.body && req.body.access_token) {
-			req.challenge = {
-				token: req.body.access_token
-			};
-		}
-		next();
-	}
-
-	function authenticate(req, res, next) {
-		if (req.challenge) {
-			options.verify(req.challenge, function done(err, auth, result) {
-				if (err) {
-					next(err);
-				} else {
-					req.authenticated = auth;
-					req.authentication = result;
-					next();
-				}
-			});
-		} else {
-			next();
-		}
-	}
-
-	var middlewares = _.chain({
-			header: fromHeader,
-			query: fromQueryString,
-			body: fromBody
-		})
-		.pick(options.from)
-		.values()
-		.concat(authenticate)
-		.value();
-
-	return async.serial(middlewares);
+	return header(_.assign({
+		scheme: 'Bearer'
+	}, options));
 };

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"auth-header": "^0.1.0",
-		"express-async": "^0.1.0",
+		"express-authentication-header": "^0.1.0",
 		"lodash": "^2.4.1"
 	},
 	"devDependencies": {
@@ -30,8 +29,5 @@
 		"chai": "^1.10.0",
 		"supertest": "^0.15.0",
 		"body-parser": "^1.10.0"
-	},
-	"peerDependencies": {
-		"express-authentication": "^0.2.0"
 	}
 }

--- a/test/spec/bearer.js
+++ b/test/spec/bearer.js
@@ -38,7 +38,7 @@ describe('bearer', function() {
 		request(this.app).get('/').set('Authorization', 'Bearer abc').end(done);
 	});
 
-	it('should set the correct token', function(done) {
+	it.skip('should set the correct token', function(done) {
 		this.app.use(function(req, res, next) {
 			expect(req.challenge).to.deep.equal({
 				token: 'abc'
@@ -48,7 +48,7 @@ describe('bearer', function() {
 		request(this.app).get('/?access_token=abc').end(done);
 	});
 
-	it('should set the correct token', function(done) {
+	it.skip('should set the correct token', function(done) {
 		this.app.use(function(req, res, next) {
 			expect(req.challenge).to.deep.equal({
 				token: 'abc'


### PR DESCRIPTION
Drops a whole bunch of existing code into something simple and more manageable. We lose functionality for pulling auth tokens from query strings and request bodies, and they might be added in later though technically they are not part of "Bearer" authentication; more geared towards OAuth2, so they might wind up in an OAuth2 library instead.
